### PR TITLE
Remove /Volumes/* prefix from Unix paths

### DIFF
--- a/apps/language_server/test/source_file_test.exs
+++ b/apps/language_server/test/source_file_test.exs
@@ -753,6 +753,16 @@ defmodule ElixirLS.LanguageServer.SourceFileTest do
       end
     end
 
+    test "unix volume" do
+      path = SourceFile.path_from_uri("file:///Volumes/PRIMARY/test/me")
+
+      if is_windows() do
+        assert path == "\\test\me"
+      else
+        assert path == "/test/me"
+      end
+    end
+
     test "wrong schema" do
       assert_raise ArgumentError, fn ->
         SourceFile.path_from_uri("untitled:Untitled-1")


### PR DESCRIPTION
Panic's [Nova](https://nova.app) code editor _nearly always_ uses paths in the form `/Volumes/Macintosh HD/Users/alias/some/path`, which causes some problems with Elixir LS because it expects paths in the form `/Users/alias/some/path`. This pull request solves these problems by removing `Volumes/name` from the return value of `path_from_uri()`.